### PR TITLE
[FIX] Unify count behaviour on validate payloads.

### DIFF
--- a/.changeset/perfect-bobcats-behave.md
+++ b/.changeset/perfect-bobcats-behave.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/utils': minor
+---
+
+FIX - Unify count behaviour on validate payloads

--- a/packages/utils/shared/inject-function-results.ts
+++ b/packages/utils/shared/inject-function-results.ts
@@ -40,11 +40,12 @@ export function injectFunctionResults(payload: Record<string, any>, filter: Filt
 				const currentValue = get(newInput, currentValuePath);
 
 				// TODO: check what to do for hours functions
-				if(functionName === "count" && currentValue === undefined){
+				if (functionName === 'count' && currentValue === undefined) {
 					// we are trying to apply a function on an object that is not present on the payload
 					// return an empty result
 					continue;
 				}
+
 				set(newInput, path, functions[functionName](currentValue));
 			}
 		}

--- a/packages/utils/shared/inject-function-results.ts
+++ b/packages/utils/shared/inject-function-results.ts
@@ -38,6 +38,13 @@ export function injectFunctionResults(payload: Record<string, any>, filter: Filt
 				if (!fieldKey || !functionName) continue;
 				const currentValuePath = parentPath ? parentPath + '.' + fieldKey : fieldKey;
 				const currentValue = get(newInput, currentValuePath);
+
+				// TODO: check what to do for hours functions
+				if(functionName === "count" && currentValue === undefined){
+					// we are trying to apply a function on an object that is not present on the payload
+					// return an empty result
+					continue;
+				}
 				set(newInput, path, functions[functionName](currentValue));
 			}
 		}

--- a/packages/utils/shared/validate-payload.test.ts
+++ b/packages/utils/shared/validate-payload.test.ts
@@ -76,14 +76,18 @@ describe('validatePayload', () => {
 
 		expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
 	});
+
 	it('returns an empty array when there is no error for filter field that does not exist in payload with special function', () => {
-        const mockFilter = { "count(items)": {
-            "_lt": "3"
-        } };
-        // intentionally empty payload to simulate "items" was never included in payload
-        const mockPayload = {};
-        expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
-    });
+		const mockFilter = {
+			'count(items)': {
+				_lt: '3',
+			},
+		};
+
+		// intentionally empty payload to simulate "items" was never included in payload
+		const mockPayload = {};
+		expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
+	});
 
 	it('returns an array of 1 when there is required error for filter field that does not exist in payload and requireAll option flag is true', () => {
 		const mockFilter = { field: { _eq: 'field' } } as Filter;

--- a/packages/utils/shared/validate-payload.test.ts
+++ b/packages/utils/shared/validate-payload.test.ts
@@ -76,6 +76,14 @@ describe('validatePayload', () => {
 
 		expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
 	});
+	it('returns an empty array when there is no error for filter field that does not exist in payload with special function', () => {
+        const mockFilter = { "count(items)": {
+            "_lt": "3"
+        } };
+        // intentionally empty payload to simulate "items" was never included in payload
+        const mockPayload = {};
+        expect(validatePayload(mockFilter, mockPayload)).toHaveLength(0);
+    });
 
 	it('returns an array of 1 when there is required error for filter field that does not exist in payload and requireAll option flag is true', () => {
 		const mockFilter = { field: { _eq: 'field' } } as Filter;


### PR DESCRIPTION
On validate-payload function, fields should be validated **only** if they are present on the payload.

However, when it was coming to special functions as **count**, the validation was trying to run on an empty object, and for count was throwing an error _Count(XX) is not a number_. 

This PR fixes the behavior at the root. 

NIT: Part of https://github.com/LaWebcapsule/directus9/issues/22
