### PR TITLE
[issues-33] Fix M2M visualization on directus_collections

### DIFF
--- a/.changeset/calm-pigs-unite.md
+++ b/.changeset/calm-pigs-unite.md
@@ -1,0 +1,8 @@
+---
+'@wbce-d9/composables': minor
+'@wbce-d9/utils': minor
+'@wbce-d9/api': minor
+'@wbce-d9/app': minor
+---
+
+Fix M2M panel visualization for collections

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -59,7 +59,11 @@ router.post(
 
 const readHandler = asyncHandler(async (req, res, next) => {
 	// [issues-33] we allow directus_collections to be read as items for m2m collection visualization
-	if (req.params['collection']!.valueOf() !== 'directus_collections' &&  req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+	if (
+		req.params['collection']!.valueOf() !== 'directus_collections' &&
+		req.params['collection']!.startsWith('directus_')
+	)
+		throw new ForbiddenException();
 
 	const service = new ItemsService(req.collection, {
 		accountability: req.accountability,

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -58,7 +58,8 @@ router.post(
 );
 
 const readHandler = asyncHandler(async (req, res, next) => {
-	if (req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
+	// [issues-33] we allow directus_collections to be read as items for m2m collection visualization
+	if (req.params['collection']!.valueOf() !== 'directus_collections' &&  req.params['collection']!.startsWith('directus_')) throw new ForbiddenException();
 
 	const service = new ItemsService(req.collection, {
 		accountability: req.accountability,

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -349,6 +349,7 @@ export function useRelationMultiple(
 					filter._and.push(previewQuery.value.filter);
 				}
 
+				// Get already linked items
 				const response = await api.get(getEndpoint(targetCollection), {
 					params: {
 						search: previewQuery.value.search,

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -54,14 +54,18 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		const { sort, limit, page, fields } = useLayoutQuery();
 
 		const { items, loading, error, totalPages, itemCount, totalCount, getItems, getTotalCount, getItemCount } =
-			useItems(collection, {
-				sort,
-				limit,
-				page,
-				fields,
-				filter,
-				search,
-			});
+			useItems(
+				collection,
+				{
+					sort,
+					limit,
+					page,
+					fields,
+					filter,
+					search,
+				},
+				true
+			);
 
 		const showingCount = computed(() => {
 			const filtering = Boolean((itemCount.value || 0) < (totalCount.value || 0) && filterUser.value);

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -63,15 +63,19 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			getItems,
 			getItemCount,
 			getTotalCount,
-		} = useItems(collection, {
-			sort,
-			limit,
-			page,
-			fields: fieldsWithRelationalAliased,
-			alias: aliasQuery,
-			filter,
-			search,
-		});
+		} = useItems(
+			collection,
+			{
+				sort,
+				limit,
+				page,
+				fields: fieldsWithRelationalAliased,
+				alias: aliasQuery,
+				filter,
+				search,
+			},
+			true
+		);
 
 		const {
 			tableSort,

--- a/app/src/views/private/components/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection.vue
@@ -95,7 +95,6 @@ export default defineComponent({
 		const { internalSelection, onSelect } = useSelection();
 
 		const { collection } = toRefs(props);
-
 		const { info: collectionInfo } = useCollection(collection);
 		const { layout, layoutOptions, layoutQuery, search, filter: presetFilter } = usePreset(collection, ref(null), true);
 

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -35,7 +35,12 @@ export type ComputedQuery = {
 	page: Ref<Query['page']> | WritableComputedRef<Query['page']>;
 };
 
-export function useItems(collection: Ref<string | null>, query: ComputedQuery): UsableItems {
+// ** bypass_collections_calls: [issues-33] we allow directus_collections to be read as items for m2m collection visualization
+export function useItems(
+	collection: Ref<string | null>,
+	query: ComputedQuery,
+	bypass_collections_calls = false
+): UsableItems {
 	const api = useApi();
 	const { primaryKeyField } = useCollection(collection);
 
@@ -43,7 +48,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	const endpoint = computed(() => {
 		if (!collection.value) return null;
-		return getEndpoint(collection.value);
+		return getEndpoint(collection.value, bypass_collections_calls);
 	});
 
 	const items = ref<Item[]>([]);

--- a/packages/utils/shared/get-endpoint.test.ts
+++ b/packages/utils/shared/get-endpoint.test.ts
@@ -6,6 +6,10 @@ describe('getEndpoint', () => {
 		expect(getEndpoint('directus_system_collection')).toBe('/system_collection');
 	});
 
+	it('When directus_collections is passed in', () => {
+		expect(getEndpoint('directus_collections')).toBe('/items/directus_collections');
+	});
+
 	it('When a non-system collection is passed in', () => {
 		expect(getEndpoint('user_collection')).toBe('/items/user_collection');
 	});

--- a/packages/utils/shared/get-endpoint.test.ts
+++ b/packages/utils/shared/get-endpoint.test.ts
@@ -6,10 +6,6 @@ describe('getEndpoint', () => {
 		expect(getEndpoint('directus_system_collection')).toBe('/system_collection');
 	});
 
-	it('When directus_collections is passed in', () => {
-		expect(getEndpoint('directus_collections')).toBe('/items/directus_collections');
-	});
-
 	it('When a non-system collection is passed in', () => {
 		expect(getEndpoint('user_collection')).toBe('/items/user_collection');
 	});

--- a/packages/utils/shared/get-endpoint.ts
+++ b/packages/utils/shared/get-endpoint.ts
@@ -1,4 +1,5 @@
 export function getEndpoint(collection: string): string {
+	// [issues-33] we allow directus_collections to be read as items for m2m collection visualization
 	if (collection == 'directus_collections') {
 		return `/items/${collection}`;
 	}

--- a/packages/utils/shared/get-endpoint.ts
+++ b/packages/utils/shared/get-endpoint.ts
@@ -1,4 +1,8 @@
 export function getEndpoint(collection: string): string {
+	if (collection == 'directus_collections') {
+		return `/items/${collection}`;
+	}
+
 	if (collection.startsWith('directus_')) {
 		return `/${collection.substring(9)}`;
 	}

--- a/packages/utils/shared/get-endpoint.ts
+++ b/packages/utils/shared/get-endpoint.ts
@@ -1,6 +1,6 @@
-export function getEndpoint(collection: string): string {
-	// [issues-33] we allow directus_collections to be read as items for m2m collection visualization
-	if (collection == 'directus_collections') {
+export function getEndpoint(collection: string, bypass_collections_calls = false): string {
+	// ** bypass_collections_calls: [issues-33] we allow directus_collections to be read as items for m2m collection visualization
+	if (bypass_collections_calls && collection == 'directus_collections') {
 		return `/items/${collection}`;
 	}
 


### PR DESCRIPTION
closes: https://github.com/LaWebcapsule/directus9/issues/33

Normally "internal" collections have the own endpoints (/collections) however in the case of directus_collections and M2M junction, this endpoint doesn't implement the full query api. This makes the M2M visualization fail on this specific internal collection.

This PR fixes this issue, allowing read operations on the /items/directus_collections route.


