### PR TITLE
Extend filter windows

### DIFF
--- a/.changeset/three-pears-lie.md
+++ b/.changeset/three-pears-lie.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/app': minor
+---
+
+Cosmetic change on presets panel

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -528,7 +528,7 @@ function useForm() {
 			type: 'string',
 			meta: {
 				interface: 'input',
-				width: 'half',
+				width: 'full',
 				options: {
 					placeholder: t('search_items'),
 				},
@@ -540,7 +540,7 @@ function useForm() {
 			type: 'json',
 			meta: {
 				interface: 'system-filter',
-				width: 'half',
+				width: 'full',
 				options: {
 					collectionField: 'collection',
 				},


### PR DESCRIPTION
This PR is a small change that allow to access full width filter windows on presets.

With the old setup, having complex filters was nearly impossible.

<img width="1263" alt="Capture d’écran 2024-01-11 à 10 42 01" src="https://github.com/LaWebcapsule/directus9/assets/10469161/c55795f5-976f-4e1e-95e5-a2987f86743c">

