### PR TITLE
Fix keycloack connection

### DIFF
--- a/.changeset/six-trainers-cough.md
+++ b/.changeset/six-trainers-cough.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/api': minor
+---
+
+Fix openid connector for keycloack

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -261,7 +261,14 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 						auth_data: JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 					});
 				}
-			} catch (e) {
+			} catch (e: any) {
+				if (e.error === 'invalid_grant') {
+					// Remove invalid token from the user store
+					await this.usersService.updateOne(user.id, {
+						auth_data: null,
+					});
+				}
+
 				throw handleError(e);
 			}
 		}


### PR DESCRIPTION
Here's what's happening:

Initially, when logging in using the Keycloak provider, the authentication data for the user is set using the refreshToken obtained from Keycloak. A session timeout of 30 minutes is configured for Keycloak, causing tokens to become invalidated after this period of inactivity. After 30 minutes of inactivity, when the user attempts to log in again, Directus utilizes the refreshToken stored in the database. However, this refreshToken fails because it has expired. The invalid token remains stored in the database, causing every subsequent login attempt to fail.

Taking out the old token will trigger a new full login from directus.
