### PR TITLE
Revoke token on logout for OpenId SSO flow.

### DIFF
--- a/.changeset/rich-camels-explain.md
+++ b/.changeset/rich-camels-explain.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/api': minor
+---
+
+Revoke tokens on sessions logout for OpenId SSO

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -254,6 +254,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 				await this.usersService.updateOne(user.id, {
 					auth_data: null,
 				});
+
+				logger.info(`[OpenID] Session closed for user.`);
 			} catch (e: any) {
 				throw handleError(e);
 			}


### PR DESCRIPTION
This PR revokes token grant on session logout for the OpenId flow.

It secures the connection to keycloack is rightly closed after an SSO session. 
