### PR TITLE
Fix oauth flows

### DIFF
--- a/.changeset/calm-queens-poke.md
+++ b/.changeset/calm-queens-poke.md
@@ -1,0 +1,6 @@
+---
+'@wbce-d9/directus9': major
+'@wbce-d9/api': major
+---
+
+Refactored and fixed Oauth and OpendId flows

--- a/.changeset/rich-camels-explain.md
+++ b/.changeset/rich-camels-explain.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/api': minor
+---
+
+Revoke tokens on sessions logout for OpenId SSO

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -21,11 +21,13 @@ const providerNames = toArray(env['AUTH_PROVIDERS']);
 const providers: Map<string, AuthDriver> = new Map();
 
 export function getAuthProvider(provider: string): AuthDriver {
-	if (!providers.has(provider)) {
+	const name = provider.toLowerCase();
+
+	if (!providers.has(name)) {
 		throw new InvalidConfigException('Auth provider not configured', { provider });
 	}
 
-	return providers.get(provider)!;
+	return providers.get(name)!;
 }
 
 export async function registerAuthProviders(): Promise<void> {
@@ -64,7 +66,7 @@ export async function registerAuthProviders(): Promise<void> {
 			return;
 		}
 
-		providers.set(name, provider);
+		providers.set(name.toLowerCase(), provider);
 	});
 }
 

--- a/api/src/auth/drivers/baseoauth.ts
+++ b/api/src/auth/drivers/baseoauth.ts
@@ -149,9 +149,9 @@ export abstract class BaseOAuthDriver extends LocalAuthDriver {
 			} catch (e: any) {
 				throw this.handleError(e);
 			}
+		} else {
+			logger.warn(`[${this.getClientName()}] Session closed for user without auth_data`);
 		}
-
-		logger.warn(`[${this.getClientName()}] Session closed for user without auth_data`);
 	}
 
 	override async login(user: User): Promise<void> {
@@ -183,11 +183,11 @@ export abstract class BaseOAuthDriver extends LocalAuthDriver {
 			} catch (e: any) {
 				throw this.handleError(e);
 			}
+		} else {
+			// If no auth connexion, throw user out
+			logger.error(`No [${this.getClientName()}] Session found`);
+			throw new InvalidCredentialsException();
 		}
-
-		// If no auth connexion, throw user out
-		logger.error(`No [${this.getClientName()}] Session found`);
-		throw new InvalidCredentialsException();
 	}
 
 	handleError = (e: any) => {

--- a/api/src/auth/drivers/baseoauth.ts
+++ b/api/src/auth/drivers/baseoauth.ts
@@ -1,0 +1,216 @@
+import { parseJSON } from '@wbce-d9/utils';
+import type { Client, TokenSet } from 'openid-client';
+import { errors, generators } from 'openid-client';
+import getDatabase from '../../database/index.js';
+import emitter from '../../emitter.js';
+import { RecordNotUniqueException } from '../../exceptions/database/record-not-unique.js';
+import {
+	InvalidCredentialsException,
+	InvalidProviderException,
+	InvalidTokenException,
+	ServiceUnavailableException,
+} from '../../exceptions/index.js';
+import logger from '../../logger.js';
+import { UsersService } from '../../services/users.js';
+import type { AuthData, User } from '../../types/index.js';
+import { LocalAuthDriver } from './local.js';
+
+export interface UserPayload {
+	provider: string;
+	first_name: any;
+	last_name: any;
+	email: any;
+	external_identifier: string;
+	role: string;
+	auth_data: any;
+}
+
+export abstract class BaseOAuthDriver extends LocalAuthDriver {
+	abstract getClient(): Promise<Client>;
+	abstract getredirectUrl(): string;
+	abstract getUserService(): UsersService;
+	abstract getConfig(): Record<string, any>;
+	abstract getClientName(): string;
+	abstract getTokenSetAndUserInfo(
+		payload: Record<string, any>
+	): Promise<[TokenSet, Record<string, unknown>, UserPayload]>;
+
+	generateCodeVerifier(): string {
+		return generators.codeVerifier();
+	}
+
+	async fetchUserId(identifier: string): Promise<string | undefined> {
+		const user = await this.knex
+			.select('id')
+			.from('directus_users')
+			.whereRaw('LOWER(??) = ?', ['external_identifier', identifier.toLowerCase()])
+			.first();
+
+		return user?.id;
+	}
+
+	override async getUserID(payload: Record<string, any>): Promise<string> {
+		if (!payload['code'] || !payload['codeVerifier'] || !payload['state']) {
+			logger.warn(`[${this.getClientName()}] No code, codeVerifier or state in payload`);
+			throw new InvalidCredentialsException();
+		}
+
+		const [tokenSet, userInfo, userPayload] = await this.getTokenSetAndUserInfo(payload);
+
+		const identifier = userPayload.external_identifier;
+
+		const userId = await this.fetchUserId(identifier);
+
+		if (userId) {
+			// Run hook so the end user has the chance to augment the
+			// user that is about to be updated
+			const updatedUserPayload = await emitter.emitFilter(
+				`auth.update`,
+				{},
+				{
+					identifier,
+					provider: this.getConfig()['provider'],
+					providerPayload: { accessToken: tokenSet.access_token, userInfo },
+				},
+				{ database: getDatabase(), schema: this.schema, accountability: null }
+			);
+
+			// Update user to update refresh_token and other properties that might have changed
+			await this.getUserService().updateOne(userId, {
+				...updatedUserPayload,
+				auth_data: userPayload.auth_data,
+			});
+
+			return userId;
+		}
+
+		//  --- NEW USER ----
+		const { provider, allowPublicRegistration, requireVerifiedEmail } = this.getConfig();
+
+		const isEmailVerified = !requireVerifiedEmail || userInfo['email_verified'];
+
+		// Is public registration allowed?
+		if (!allowPublicRegistration || !isEmailVerified) {
+			logger.warn(
+				`[${this.getClientName()}] User doesn't exist, and public registration not allowed for provider "${provider}"`
+			);
+
+			throw new InvalidCredentialsException();
+		}
+
+		// Run hook so the end user has the chance to augment the
+		// user that is about to be created
+		const updatedUserPayload = await emitter.emitFilter(
+			`auth.create`,
+			userPayload,
+			{
+				identifier,
+				provider: this.getConfig()['provider'],
+				providerPayload: { accessToken: tokenSet.access_token, userInfo },
+			},
+			{ database: getDatabase(), schema: this.schema, accountability: null }
+		);
+
+		try {
+			await this.getUserService().createOne(updatedUserPayload);
+		} catch (e) {
+			if (e instanceof RecordNotUniqueException) {
+				logger.warn(e, '[${this.getClientName()}] Failed to register user. User not unique');
+				throw new InvalidProviderException();
+			}
+
+			throw e;
+		}
+
+		return (await this.fetchUserId(identifier)) as string;
+	}
+
+	override async logout(user: User): Promise<void> {
+		let authData = user.auth_data as AuthData;
+
+		if (typeof authData === 'string') {
+			try {
+				authData = parseJSON(authData);
+			} catch {
+				logger.warn(`[${this.getClientName()}] Session data isn't valid JSON: ${authData}`);
+			}
+		}
+
+		if (authData?.['refreshToken']) {
+			try {
+				const client = await this.getClient();
+				await client.revoke(authData['refreshToken']);
+
+				await this.getUserService().updateOne(user.id, {
+					auth_data: null,
+				});
+
+				logger.info(`[${this.getClientName()}] Session closed for user.`);
+			} catch (e: any) {
+				throw this.handleError(e);
+			}
+		}
+
+		logger.warn(`[${this.getClientName()}] Session closed for user without auth_data`);
+	}
+
+	override async login(user: User): Promise<void> {
+		return this.refresh(user);
+	}
+
+	override async refresh(user: User): Promise<void> {
+		let authData = user.auth_data as AuthData;
+
+		if (typeof authData === 'string') {
+			try {
+				authData = parseJSON(authData);
+			} catch {
+				logger.warn(`[${this.getClientName()}] Session data isn't valid JSON: ${authData}`);
+			}
+		}
+
+		if (authData?.['refreshToken']) {
+			try {
+				const client = await this.getClient();
+				const tokenSet = await client.refresh(authData['refreshToken']);
+
+				// Update user refreshToken if provided
+				if (tokenSet.refresh_token) {
+					await this.getUserService().updateOne(user.id, {
+						auth_data: JSON.stringify({ refreshToken: tokenSet.refresh_token }),
+					});
+				}
+			} catch (e: any) {
+				throw this.handleError(e);
+			}
+		}
+
+		// If no auth connexion, throw user out
+		logger.error(`No [${this.getClientName()}] Session found`);
+		throw new InvalidCredentialsException();
+	}
+
+	handleError = (e: any) => {
+		if (e instanceof errors.OPError) {
+			if (e.error === 'invalid_grant') {
+				// Invalid token
+				logger.trace(e, `[${this.getClientName()}] Invalid grant`);
+				return new InvalidTokenException();
+			}
+
+			// Server response error
+			logger.trace(e, `[${this.getClientName()}] Unknown OP error`);
+			return new ServiceUnavailableException('Service returned unexpected response', {
+				service: 'openid',
+				message: e.error_description,
+			});
+		} else if (e instanceof errors.RPError) {
+			// Internal client error
+			logger.trace(e, `[${this.getClientName()}] Unknown RP error`);
+			return new InvalidCredentialsException();
+		}
+
+		logger.trace(e, `[${this.getClientName()}] Unknown error`);
+		return e;
+	};
+}

--- a/api/src/auth/drivers/baseoauth.ts
+++ b/api/src/auth/drivers/baseoauth.ts
@@ -115,7 +115,7 @@ export abstract class BaseOAuthDriver extends LocalAuthDriver {
 			await this.getUserService().createOne(updatedUserPayload);
 		} catch (e) {
 			if (e instanceof RecordNotUniqueException) {
-				logger.warn(e, '[${this.getClientName()}] Failed to register user. User not unique');
+				logger.warn(e, `[${this.getClientName()}] Failed to register user. User not unique`);
 				throw new InvalidProviderException();
 			}
 

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -18,7 +18,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
-import { BaseOAuthDriver, UserPayload } from './baseoauth.js';
+import { BaseOAuthDriver, type UserPayload } from './baseoauth.js';
 
 export class OAuth2AuthDriver extends BaseOAuthDriver {
 	client: Client;

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -3,19 +3,11 @@ import type { Accountability } from '@wbce-d9/types';
 import express, { Router } from 'express';
 import flatten from 'flat';
 import jwt from 'jsonwebtoken';
-import type { BaseClient, Client } from 'openid-client';
+import type { BaseClient, Client, TokenSet } from 'openid-client';
 import { generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth.js';
-import getDatabase from '../../database/index.js';
-import emitter from '../../emitter.js';
 import env from '../../env.js';
-import { RecordNotUniqueException } from '../../exceptions/database/record-not-unique.js';
-import {
-	InvalidConfigException,
-	InvalidCredentialsException,
-	InvalidProviderException,
-	InvalidTokenException,
-} from '../../exceptions/index.js';
+import { InvalidConfigException, InvalidCredentialsException, InvalidTokenException } from '../../exceptions/index.js';
 import logger from '../../logger.js';
 import { respond } from '../../middleware/respond.js';
 import { AuthenticationService } from '../../services/authentication.js';
@@ -26,7 +18,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
-import { BaseOAuthDriver } from './baseoauth.js';
+import { BaseOAuthDriver, UserPayload } from './baseoauth.js';
 
 export class OpenIDAuthDriver extends BaseOAuthDriver {
 	client: Promise<Client>;
@@ -127,12 +119,9 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 		}
 	}
 
-	override async getUserID(payload: Record<string, any>): Promise<string> {
-		if (!payload['code'] || !payload['codeVerifier'] || !payload['state']) {
-			logger.warn('[OpenID] No code, codeVerifier or state in payload');
-			throw new InvalidCredentialsException();
-		}
-
+	async getTokenSetAndUserInfo(
+		payload: Record<string, any>
+	): Promise<[TokenSet, Record<string, unknown>, UserPayload]> {
 		let tokenSet;
 		let userInfo;
 
@@ -161,7 +150,7 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 		// Flatten response to support dot indexes
 		userInfo = flatten(userInfo) as Record<string, unknown>;
 
-		const { provider, identifierKey, allowPublicRegistration, requireVerifiedEmail } = this.config;
+		const { provider, identifierKey } = this.config;
 
 		const email = userInfo['email'] ? String(userInfo['email']) : undefined;
 		// Fallback to email if explicit identifier not found
@@ -182,66 +171,7 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 		};
 
-		const userId = await this.fetchUserId(identifier);
-
-		if (userId) {
-			// Run hook so the end user has the chance to augment the
-			// user that is about to be updated
-			const updatedUserPayload = await emitter.emitFilter(
-				`auth.update`,
-				{},
-				{
-					identifier,
-					provider: this.config['provider'],
-					providerPayload: { accessToken: tokenSet.access_token, userInfo },
-				},
-				{ database: getDatabase(), schema: this.schema, accountability: null }
-			);
-
-			// Update user to update refresh_token and other properties that might have changed
-			await this.usersService.updateOne(userId, {
-				...updatedUserPayload,
-				auth_data: userPayload.auth_data,
-			});
-
-			return userId;
-		}
-
-		//  --- NEW USER ----
-
-		const isEmailVerified = !requireVerifiedEmail || userInfo['email_verified'];
-
-		// Is public registration allowed?
-		if (!allowPublicRegistration || !isEmailVerified) {
-			logger.warn(`[OpenID] User doesn't exist, and public registration not allowed for provider "${provider}"`);
-			throw new InvalidCredentialsException();
-		}
-
-		// Run hook so the end user has the chance to augment the
-		// user that is about to be created
-		const updatedUserPayload = await emitter.emitFilter(
-			`auth.create`,
-			userPayload,
-			{
-				identifier,
-				provider: this.config['provider'],
-				providerPayload: { accessToken: tokenSet.access_token, userInfo },
-			},
-			{ database: getDatabase(), schema: this.schema, accountability: null }
-		);
-
-		try {
-			await this.usersService.createOne(updatedUserPayload);
-		} catch (e) {
-			if (e instanceof RecordNotUniqueException) {
-				logger.warn(e, '[OpenID] Failed to register user. User not unique');
-				throw new InvalidProviderException();
-			}
-
-			throw e;
-		}
-
-		return (await this.fetchUserId(identifier)) as string;
+		return [tokenSet, userInfo, userPayload];
 	}
 }
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -185,7 +185,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			// user that is about to be updated
 			const updatedUserPayload = await emitter.emitFilter(
 				`auth.update`,
-				{ auth_data: userPayload.auth_data },
+				{},
 				{
 					identifier,
 					provider: this.config['provider'],
@@ -195,7 +195,10 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			);
 
 			// Update user to update refresh_token and other properties that might have changed
-			await this.usersService.updateOne(userId, updatedUserPayload);
+			await this.usersService.updateOne(userId, {
+				...updatedUserPayload,
+				auth_data: userPayload.auth_data,
+			});
 
 			return userId;
 		}

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -18,7 +18,7 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
-import { BaseOAuthDriver, UserPayload } from './baseoauth.js';
+import { BaseOAuthDriver, type UserPayload } from './baseoauth.js';
 
 export class OpenIDAuthDriver extends BaseOAuthDriver {
 	client: Promise<Client>;

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -128,7 +128,7 @@ export class AuthenticationService {
 				await stall(STALL_TIME, timeStart);
 				throw new InvalidCredentialsException();
 			}
-		} else if (user.provider !== providerName) {
+		} else if (user.provider.toLowerCase() !== providerName.toLowerCase()) {
 			await stall(STALL_TIME, timeStart);
 			throw new InvalidProviderException();
 		}


### PR DESCRIPTION
This PR represents a refactor of the OAuth and OpenID clients, aimed at enhancing security measures and improving user experience. 

Key changes include implementing a more robust logout system, revoking grants obtained during login, and implementing stricter handling of token refresh and absence thereof. 

Additionally, it removes a workaround previously introduced to address keycloak OAuth session issues. 

Furthermore, it introduces a new flag, `_UPDATE_USER_ON_LOGIN`, providing more flexibility in managing the Single Sign-On (SSO) OpenID login experience.