### PR TITLE
Add partitionned to cookies

### DIFF
--- a/.changeset/kind-gorillas-hang.md
+++ b/.changeset/kind-gorillas-hang.md
@@ -1,0 +1,7 @@
+---
+'@wbce-d9/api': minor
+---
+
+This pull request introduces the "Partitioned" tag for the sessions cookie to prevent it from being treated as a
+third-party cookie by browsers. Additionally, it adds an environment variable REFRESH_TOKEN_COOKIE_PARTITIONED which can
+be set to false to deactivate this feature.

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -3,9 +3,9 @@ import { Router } from 'express';
 import Joi from 'joi';
 import type { Client, Error, LDAPResult, SearchCallbackResponse, SearchEntry } from 'ldapjs';
 import ldap from 'ldapjs';
+import { GET_SET_HEADER } from '../../constants.js';
 import getDatabase from '../../database/index.js';
 import emitter from '../../emitter.js';
-import env from '../../env.js';
 import { RecordNotUniqueException } from '../../exceptions/database/record-not-unique.js';
 import {
 	InvalidConfigException,
@@ -22,7 +22,6 @@ import { UsersService } from '../../services/users.js';
 import type { AuthDriverOptions, User } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
-import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { AuthDriver } from '../auth.js';
 
 interface UserInfo {
@@ -443,13 +442,7 @@ export function createLDAPAuthRouter(provider: string): Router {
 			}
 
 			if (mode === 'cookie') {
-				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
-					httpOnly: true,
-					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
-					maxAge: getMilliseconds(env['REFRESH_TOKEN_TTL']),
-					secure: env['REFRESH_TOKEN_COOKIE_SECURE'] ?? false,
-					sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
-				});
+				res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 			}
 
 			res.locals['payload'] = payload;

--- a/api/src/auth/drivers/local.ts
+++ b/api/src/auth/drivers/local.ts
@@ -3,7 +3,7 @@ import argon2 from 'argon2';
 import { Router } from 'express';
 import Joi from 'joi';
 import { performance } from 'perf_hooks';
-import { COOKIE_OPTIONS } from '../../constants.js';
+import { GET_SET_HEADER } from '../../constants.js';
 import env from '../../env.js';
 import { InvalidCredentialsException, InvalidPayloadException } from '../../exceptions/index.js';
 import { respond } from '../../middleware/respond.js';
@@ -100,7 +100,7 @@ export function createLocalAuthRouter(provider: string): Router {
 			}
 
 			if (mode === 'cookie') {
-				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
+				res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 			}
 
 			res.locals['payload'] = payload;

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -6,6 +6,7 @@ import jwt from 'jsonwebtoken';
 import type { BaseClient, Client, TokenSet } from 'openid-client';
 import { generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth.js';
+import { GET_SET_HEADER } from '../../constants.js';
 import env from '../../env.js';
 import { InvalidConfigException, InvalidCredentialsException, InvalidTokenException } from '../../exceptions/index.js';
 import logger from '../../logger.js';
@@ -16,7 +17,6 @@ import type { AuthDriverOptions } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
-import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
 import { BaseOAuthDriver, type UserPayload } from './baseoauth.js';
 
@@ -258,14 +258,7 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 			const { accessToken, refreshToken, expires } = authResponse;
 
 			if (redirect) {
-				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
-					httpOnly: true,
-					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
-					maxAge: getMilliseconds(env['REFRESH_TOKEN_TTL']),
-					secure: env['REFRESH_TOKEN_COOKIE_SECURE'] ?? false,
-					sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
-				});
-
+				res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 				return res.redirect(redirect);
 			}
 

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -6,6 +6,7 @@ import jwt from 'jsonwebtoken';
 import type { AuthorizationParameters, BaseClient, Client, TokenSet } from 'openid-client';
 import { generators, Issuer } from 'openid-client';
 import { getAuthProvider } from '../../auth.js';
+import { GET_SET_HEADER } from '../../constants.js';
 import env from '../../env.js';
 import { InvalidConfigException, InvalidCredentialsException, InvalidTokenException } from '../../exceptions/index.js';
 import logger from '../../logger.js';
@@ -16,7 +17,6 @@ import type { AuthDriverOptions } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
-import { getMilliseconds } from '../../utils/get-milliseconds.js';
 import { Url } from '../../utils/url.js';
 import { BaseOAuthDriver, type UserPayload } from './baseoauth.js';
 
@@ -296,14 +296,7 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 			const { accessToken, refreshToken, expires } = authResponse;
 
 			if (redirect) {
-				res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, {
-					httpOnly: true,
-					domain: env['REFRESH_TOKEN_COOKIE_DOMAIN'],
-					maxAge: getMilliseconds(env['REFRESH_TOKEN_TTL']),
-					secure: env['REFRESH_TOKEN_COOKIE_SECURE'] ?? false,
-					sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
-				});
-
+				res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 				return res.redirect(redirect);
 			}
 

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -3,7 +3,7 @@ import { BaseException } from '@wbce-d9/exceptions';
 import express, { Router } from 'express';
 import * as samlify from 'samlify';
 import { getAuthProvider } from '../../auth.js';
-import { COOKIE_OPTIONS } from '../../constants.js';
+import { COOKIE_OPTIONS, GET_SET_HEADER } from '../../constants.js';
 import getDatabase from '../../database/index.js';
 import emitter from '../../emitter.js';
 import env from '../../env.js';
@@ -170,7 +170,7 @@ export function createSAMLAuthRouter(providerName: string) {
 				};
 
 				if (relayState) {
-					res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
+					res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 					return res.redirect(relayState);
 				}
 

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -67,6 +67,19 @@ export const COOKIE_OPTIONS: CookieOptions = {
 	sameSite: (env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
 };
 
+export const GET_SET_HEADER = (cookieValue: string) => {
+	const domainHeader = env['REFRESH_TOKEN_COOKIE_DOMAIN'] ? ` Domain=${env['REFRESH_TOKEN_COOKIE_DOMAIN']};` : '';
+	const partitionedHeader = env['REFRESH_TOKEN_COOKIE_PARTITIONED'] == false ? '' : ` Partitioned;`;
+
+	const cookieHeaderValue = `${env['REFRESH_TOKEN_COOKIE_NAME']}=${cookieValue}; HttpOnly; Max-Age=${getMilliseconds(
+		env['REFRESH_TOKEN_TTL']
+	)}; Secure=${env['REFRESH_TOKEN_COOKIE_SECURE'] ?? false}; SameSite=${
+		(env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict'
+	};${domainHeader}${partitionedHeader}`;
+
+	return cookieHeaderValue;
+};
+
 export const OAS_REQUIRED_SCHEMAS = ['Diff', 'Schema', 'Query', 'x-metadata'];
 
 /** Formats from which transformation is supported */

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -75,7 +75,7 @@ export const GET_SET_HEADER = (cookieValue: string) => {
 		env['REFRESH_TOKEN_TTL']
 	)}; Secure=${env['REFRESH_TOKEN_COOKIE_SECURE'] ?? false}; SameSite=${
 		(env['REFRESH_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict'
-	};${domainHeader}${partitionedHeader}`;
+	}; Path=/;${domainHeader}${partitionedHeader}`;
 
 	return cookieHeaderValue;
 };

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -7,7 +7,7 @@ import {
 	createOpenIDAuthRouter,
 	createSAMLAuthRouter,
 } from '../auth/drivers/index.js';
-import { COOKIE_OPTIONS, DEFAULT_AUTH_PROVIDER } from '../constants.js';
+import { DEFAULT_AUTH_PROVIDER, GET_SET_HEADER } from '../constants.js';
 import env from '../env.js';
 import { InvalidPayloadException } from '../exceptions/index.js';
 import logger from '../logger.js';
@@ -97,7 +97,7 @@ router.post(
 		}
 
 		if (mode === 'cookie') {
-			res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
+			res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 		}
 
 		res.locals['payload'] = payload;

--- a/api/src/controllers/shares.ts
+++ b/api/src/controllers/shares.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import Joi from 'joi';
-import { COOKIE_OPTIONS, UUID_REGEX } from '../constants.js';
-import env from '../env.js';
+import { GET_SET_HEADER, UUID_REGEX } from '../constants.js';
 import { ForbiddenException, InvalidPayloadException } from '../exceptions/index.js';
 import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
@@ -36,7 +35,7 @@ router.post(
 
 		const { accessToken, refreshToken, expires } = await service.login(req.body);
 
-		res.cookie(env['REFRESH_TOKEN_COOKIE_NAME'], refreshToken, COOKIE_OPTIONS);
+		res.setHeader('Set-Cookie', GET_SET_HEADER(refreshToken));
 
 		res.locals['payload'] = { data: { access_token: accessToken, expires } };
 


### PR DESCRIPTION
This pull request introduces the "Partitioned" tag for the sessions cookie to prevent it from being treated as a third-party cookie by browsers. Additionally, it adds an environment variable REFRESH_TOKEN_COOKIE_PARTITIONED which can be set to false to deactivate this feature.






