### PR TITLE
Remove Directus version

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -16,19 +16,13 @@ import { loadExtensions, registerExtensions } from './extensions';
 init();
 
 async function init() {
-	const version = __DIRECTUS_VERSION__;
-
 	console.log(DIRECTUS_LOGO);
 
 	console.info(
 		`Hey! Interested in helping build this open-source data management platform?\nIf so, join our growing team of contributors at: https://directus.chat`
 	);
 
-	if (import.meta.env.DEV) {
-		console.info(`%c🐰 Starting Directus v${version}...`, 'color:Green');
-	} else {
-		console.info(`%c🐰 Starting Directus...`, 'color:Green');
-	}
+	console.info(`%c🐰 Starting Directus...`, 'color:Green');
 
 	console.time('🕓 Application Loaded');
 
@@ -58,10 +52,6 @@ async function init() {
 	console.timeEnd('🕓 Application Loaded');
 
 	console.group(`%c✨ Project Information`, 'color:DodgerBlue'); // groupCollapsed
-
-	if (import.meta.env.DEV) {
-		console.info(`%cVersion: v${version}`, 'color:DodgerBlue');
-	}
 
 	console.info(`%cEnvironment: ${import.meta.env.MODE}`, 'color:DodgerBlue');
 	console.groupEnd();

--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -26,14 +26,15 @@
 </template>
 
 <script lang="ts">
+import { useServerStore } from '@/stores/server';
 import { computed, defineComponent } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
 	setup() {
-		const version = __DIRECTUS_VERSION__;
-
 		const { t } = useI18n();
+		const { directus } = useServerStore();
+		const version = directus.version;
 
 		const navItems = [
 			{

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-declare const __DIRECTUS_VERSION__: string;

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -17,7 +17,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { searchForWorkspaceRoot } from 'vite';
 import { defineConfig } from 'vitest/config';
-import { version } from '../directus/package.json';
 
 const API_PATH = path.join('..', 'api');
 const EXTENSIONS_PATH = path.join(API_PATH, 'extensions');

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -24,9 +24,6 @@ const EXTENSIONS_PATH = path.join(API_PATH, 'extensions');
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	define: {
-		__DIRECTUS_VERSION__: JSON.stringify(version),
-	},
 	plugins: [
 		directusExtensions(),
 		vue(),


### PR DESCRIPTION
The exact Directus version number is being shipped in compiled JS bundles which are accessible without authentication. With this information a malicious attacker can trivially look for known vulnerabilities in Directus core or any of its shipped dependencies in that specific running version.