### PR TITLE
add an environment variable to enable or disable the x-powered-by hea…

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -143,10 +143,12 @@ export default async function createApp(): Promise<express.Application> {
 
 	app.use(expressLogger);
 
-	app.use((_req, res, next) => {
-		res.setHeader('X-Powered-By', 'Directus');
-		next();
-	});
+	if (env['X_POWERED_BY_ENABLED'] === true) {
+		app.use((_req, res, next) => {
+			res.setHeader('X-Powered-By', 'Directus');
+			next();
+		});
+	}
 
 	if (env['CORS_ENABLED'] === true) {
 		app.use(cors);

--- a/api/src/cli/utils/create-env/env-stub.liquid
+++ b/api/src/cli/utils/create-env/env-stub.liquid
@@ -230,6 +230,9 @@ REFRESH_TOKEN_COOKIE_NAME="directus_refresh_token"
 # and it should be greater than the time taken for a login request with an invalid password [500]
 # LOGIN_STALL_TIME=500
 
+# Whether or not to enable the X-Powered-By Header [true]
+X_POWERED_BY_ENABLED=false
+
 # Whether or not to enable the CORS headers [false]
 CORS_ENABLED=true
 

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -58,6 +58,7 @@ const allowedEnvironmentVars = [
 	'HSTS_.+',
 	// hashing
 	'HASH_.+',
+	'X_POWERED_BY_ENABLED',
 	// cors
 	'CORS_ENABLED',
 	'CORS_ORIGIN',
@@ -240,6 +241,8 @@ const defaults: Record<string, any> = {
 	SERVER_SHUTDOWN_TIMEOUT: 1000,
 
 	ROOT_REDIRECT: './admin',
+
+	X_POWERED_BY_ENABLED: true,
 
 	CORS_ENABLED: false,
 	CORS_ORIGIN: false,

--- a/docs/self-hosted/config-options.md
+++ b/docs/self-hosted/config-options.md
@@ -206,6 +206,7 @@ prefixing the value with `{type}:`. The following types are available:
 | `MAX_BATCH_MUTATION`       | The maximum number of items for batch mutations when creating, updating and deleting.                      | `Infinity`                   |
 | `MAX_RELATIONAL_DEPTH`     | The maximum depth when filtering / querying relational fields, with a minimum value of `2`.                | `10`                         |
 | `ROBOTS_TXT`               | What the `/robots.txt` endpoint should return                                                              | `User-agent: *\nDisallow: /` |
+| `X_POWERED_BY_ENABLED`               | Whether the response should return the X-Powered-By Directus Header                                                              | `true` |
 
 <sup>[1]</sup> The PUBLIC_URL value is used for things like OAuth redirects, forgot-password emails, and logos that
 needs to be publicly available on the internet.


### PR DESCRIPTION
Currently, Directus9 adds an X-Powered-By Directus header in all responses.

This PR adds an environment variable `X_POWERED_BY_ENABLED` to enable / disable this header.
