### PR TITLE
fix directus version

### DIFF
--- a/app/src/modules/settings/components/navigation.vue
+++ b/app/src/modules/settings/components/navigation.vue
@@ -33,8 +33,8 @@ import { useI18n } from 'vue-i18n';
 export default defineComponent({
 	setup() {
 		const { t } = useI18n();
-		const { directus } = useServerStore();
-		const version = directus.version;
+		const { info } = useServerStore();
+		const version = info.directus.version;
 
 		const navItems = [
 			{


### PR DESCRIPTION
In the latest version of directus, a bug was introduced in navigation.vue : we couldn't fetch the directus version, and thus the view was broken.

This PR fixes the version bug.
