### PR TITLE
fix alias security vulnerability CVE-2024-34708

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -83,7 +83,7 @@ export default async function runAST(
 
 		// Run the items through the special transforms
 		const payloadService = new PayloadService(collection, { knex, schema });
-		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems);
+		let items: null | Item | Item[] = await payloadService.processValues('read', rawItems, query.alias ?? {});
 
 		if (!items || (Array.isArray(items) && items.length === 0)) return items;
 

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -254,6 +254,84 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+		describe('processValues', () => {
+			let service: PayloadService;
+
+			const hashedField = 'password';
+			const stringField = 'string';
+			const HASHED_SECURITY = '**********';
+
+			beforeEach(() => {
+				service = new PayloadService('test', {
+					knex: db,
+					schema: {
+						collections: {
+							test: {
+								collection: 'test',
+								primary: 'id',
+								singleton: false,
+								sortField: null,
+								note: null,
+								accountability: null,
+								fields: {
+									[hashedField]: {
+										field: hashedField,
+										defaultValue: null,
+										nullable: true,
+										generated: false,
+										type: 'hash',
+										dbType: 'nvarchar',
+										precision: null,
+										scale: null,
+										special: ['hash', 'conceal'],
+										note: null,
+										validation: null,
+										alias: false,
+									},
+									[stringField]: {
+										field: stringField,
+										defaultValue: null,
+										nullable: true,
+										generated: false,
+										type: 'string',
+										dbType: 'nvarchar',
+										precision: null,
+										scale: null,
+										special: [],
+										note: null,
+										validation: null,
+										alias: false,
+									},
+								},
+							},
+						},
+						relations: [],
+					},
+				});
+			});
+
+			it('processing special fields', async () => {
+				const result = await service.processValues('read', {
+					string: 'clear-value',
+					password: 'secret-value',
+				});
+
+				expect(result).toMatchObject({ string: 'clear-value', password: HASHED_SECURITY });
+			});
+
+			it('processing aliassed special fields', async () => {
+				const result = await service.processValues(
+					'read',
+					{
+						other_string: 'clear-value',
+						other_password: 'secret-value',
+					},
+					{ other_string: 'string', other_password: 'password' }
+				);
+
+				expect(result).toMatchObject({ other_string: 'clear-value', other_password: HASHED_SECURITY });
+			});
+		});
 	});
 });
 

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -254,6 +254,7 @@ describe('Integration Tests', () => {
 				});
 			});
 		});
+
 		describe('processValues', () => {
 			let service: PayloadService;
 

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -148,9 +148,12 @@ export class PayloadService {
 
 	processValues(action: Action, payloads: Partial<Item>[]): Promise<Partial<Item>[]>;
 	processValues(action: Action, payload: Partial<Item>): Promise<Partial<Item>>;
+	processValues(action: Action, payloads: Partial<Item>[], aliasMap: Record<string, string>): Promise<Partial<Item>[]>;
+	processValues(action: Action, payload: Partial<Item>, aliasMap: Record<string, string>): Promise<Partial<Item>>;
 	async processValues(
 		action: Action,
-		payload: Partial<Item> | Partial<Item>[]
+		payload: Partial<Item> | Partial<Item>[],
+		aliasMap: Record<string, string> = {}
 	): Promise<Partial<Item> | Partial<Item>[]> {
 		const processedPayload = toArray(payload);
 
@@ -161,6 +164,16 @@ export class PayloadService {
 		let specialFieldsInCollection = Object.entries(this.schema.collections[this.collection]!.fields).filter(
 			([_name, field]) => field.special && field.special.length > 0
 		);
+
+		const aliasEntries = Object.entries(aliasMap);
+
+		for (const [name, field] of specialFieldsInCollection) {
+			for (const [aliasName, fieldName] of aliasEntries) {
+				if (fieldName === name) {
+					specialFieldsInCollection.push([aliasName, { ...field, field: aliasName }]);
+				}
+			}
+		}
 
 		if (action === 'read') {
 			specialFieldsInCollection = specialFieldsInCollection.filter(([name]) => {


### PR DESCRIPTION
Directus9 allow redacted data extraction on the API through "alias".

This security vulnerability is documented [here](https://nvd.nist.gov/vuln/detail/CVE-2024-34708)  and [here](https://github.com/directus/directus/security/advisories/GHSA-p8v3-m643-4xqx).

This PR fixes the issue by checking if the alias fields are supposed to be hashed.