### PR TITLE
Potential fix for code scanning alert no. 9: Missing CSRF middleware

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -162,7 +162,8 @@
 		"tsx": "3.12.6",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
-		"wellknown": "0.5.0"
+		"wellknown": "0.5.0",
+		"lusca": "^1.7.0"
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,4 +1,5 @@
 import cookieParser from 'cookie-parser';
+import lusca from 'lusca';
 import type { Request, RequestHandler, Response } from 'express';
 import express from 'express';
 import type { ServerResponse } from 'http';
@@ -169,6 +170,7 @@ export default async function createApp(): Promise<express.Application> {
 	});
 
 	app.use(cookieParser());
+	app.use(lusca.csrf());
 
 	app.use(extractToken);
 


### PR DESCRIPTION
Potential fix for [https://github.com/LaWebcapsule/directus9/security/code-scanning/9](https://github.com/LaWebcapsule/directus9/security/code-scanning/9)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a CSRF middleware that can be easily integrated into the application. We will import the `lusca` package and use its CSRF middleware in the application setup.

1. Install the `lusca` package if it is not already installed.
2. Import the `lusca` package in the `api/src/app.ts` file.
3. Add the CSRF middleware to the Express application before any state-changing routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
