### PR TITLE
Potential fix for code scanning alert no. 30: Reflected cross-site scripting

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -162,7 +162,8 @@
 		"tsx": "3.12.6",
 		"uuid": "9.0.0",
 		"uuid-validate": "0.0.3",
-		"wellknown": "0.5.0"
+		"wellknown": "0.5.0",
+		"escape-html": "^1.0.3"
 	},
 	"devDependencies": {
 		"@ngneat/falso": "6.4.0",

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -1,4 +1,5 @@
 import { parse as parseBytesConfiguration } from 'bytes';
+import escape from 'escape-html';
 import type { RequestHandler } from 'express';
 import { getCache, setCacheValue } from '../cache.js';
 import env from '../env.js';
@@ -68,9 +69,10 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		}
 
 		if (req.sanitizedQuery.export === 'xml') {
+			const sanitizedData = escape(res.locals['payload']?.data);
 			res.attachment(`${filename}.xml`);
 			res.set('Content-Type', 'text/xml');
-			return res.status(200).send(exportService.transform(res.locals['payload']?.data, 'xml'));
+			return res.status(200).send(exportService.transform(sanitizedData, 'xml'));
 		}
 
 		if (req.sanitizedQuery.export === 'csv') {


### PR DESCRIPTION
Potential fix for [https://github.com/LaWebcapsule/directus9/security/code-scanning/30](https://github.com/LaWebcapsule/directus9/security/code-scanning/30)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input used in the response is properly sanitized or encoded. In this case, we should sanitize the `res.locals['payload']?.data` before passing it to the `exportService.transform` method.

The best way to fix this issue is to use a library like `escape-html` to sanitize the user input before it is included in the response. This will prevent any malicious scripts from being executed in the user's browser.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
