### PR TITLE
Fix blackbox other vendors

### DIFF
--- a/.github/workflows/blackbox-main.yml
+++ b/.github/workflows/blackbox-main.yml
@@ -43,16 +43,6 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
-      - name: Install Oracle client
-        if: matrix.vendor == 'oracle'
-        run: |
-          sudo apt update -y && sudo apt install -y alien libaio1 && \
-          wget https://download.oracle.com/otn_software/linux/instantclient/214000/$ORACLE_DL && \
-          sudo alien -i $ORACLE_DL && \
-          pnpm -w -D add oracledb@5.5.0
-        env:
-          ORACLE_DL: oracle-instantclient-basic-21.4.0.0.0-1.el8.x86_64.rpm
-
       - name: Start services (SQLite)
         if: matrix.vendor == 'sqlite3'
         run:

--- a/api/package.json
+++ b/api/package.json
@@ -218,6 +218,7 @@
 		"memcached": "2.2.2",
 		"mysql": "2.18.1",
 		"nodemailer-mailgun-transport": "2.1.5",
+		"oracledb": "^6.8.0",
 		"pg": "8.10.0",
 		"sqlite3": "5.1.6",
 		"tedious": "18.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       nodemailer-mailgun-transport:
         specifier: 2.1.5
         version: 2.1.5
+      oracledb:
+        specifier: ^6.8.0
+        version: 6.8.0
       pg:
         specifier: 8.10.0
         version: 8.10.0
@@ -15302,6 +15305,13 @@ packages:
       strip-ansi: 7.1.0
       wcwidth: 1.0.1
     dev: false
+
+  /oracledb@6.8.0:
+    resolution: {integrity: sha512-A4ds4n4xtjPTzk1gwrHWuMeWsEcrScF0GFgVebGrhNpHSAzn6eDwMKcSbakZODKfFcI099iqhmqWsgko8D+7Ww==}
+    engines: {node: '>=14.6'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}

--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - 6101:5432
 
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: secret


### PR DESCRIPTION
## Change description

> Mysql blackbox tests keep failing with error `MySQL [FAILED: Couldn't connect to DB]`. They were failing because of this error `[ERROR] [MY-000067] [Server] unknown variable 'default-authentication-plugin=mysql_native_password'.`. This option exists in v8.0 but not in 8.4, so specified in docker-compose file which version to use.

> Oracle blackbox tests keep failing at the step `Install Oracle Client` with error 
```
Package libaio1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libaio1' has no installation candidate
```
> The workaround is to install `nodeoracle-db` and to remove the failing step in the workflow


## Type of change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix #42

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] Application changes have been tested thoroughly -> no changes to application
- [ ] Automated tests covering modified code pass -> cannot seem to test oracle locally successfully

### Security
N/A
- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Network
N/A
- [ ] Changes to network configurations have been reviewed
- [ ] Any newly exposed public endpoints or data have gone through security review

### Code review

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [X] reviewers assigned 
- [ ] Pull request linked to task tracker where applicable

