### PR TITLE
Fix: Run Script Operation Not Executing in Directus Flows

### DIFF
--- a/api/src/operations/exec/index.ts
+++ b/api/src/operations/exec/index.ts
@@ -9,7 +9,7 @@ type ExecutionOptions = {
 };
 
 export default defineOperationApi<ExecutionOptions>({
-	id: 'execute_script',
+	id: 'exec',
 	handler: async ({ code }, { data, env, logger }) => {
 		// Fetching execution limits and environment variables
 		const memoryLimit = env['FLOWS_SCRIPT_MAX_MEMORY'];


### PR DESCRIPTION
## Change description

**This PR fixes the Run Script operation not executing in Directus flows.**

The issue was caused by a mismatch in the operation ID:
The script operation was renamed from `exec` to `execute_script` in [this commit](https://github.com/LaWebcapsule/directus9/pull/96/files#diff-3df7a8c831a5d2f08a3a5d71657d06247ff6615a48c80c6f1fb847624b01143cR12), but Directus was not updated to recognize the new ID.

As a result, when a flow reached the `Run Script` operation, it silently failed to execute the script and logged the following warning:

```
WARN: Couldn't find operation exec
```

This PR reverts the operation ID from `execute_script` back to `exec`, restoring expected behavior.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#113](https://github.com/LaWebcapsule/directus9/issues/113)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Network

- [ ] Changes to network configurations have been reviewed
- [ ] Any newly exposed public endpoints or data have gone through security review

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] reviewers assigned 
- [ ] Pull request linked to task tracker where applicable

