### PR TITLE
Fix set cache

### DIFF
--- a/.changeset/blue-laws-brush.md
+++ b/.changeset/blue-laws-brush.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/api': patch
+---
+
+fix url to be bypassed by catch

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -29,7 +29,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		!req.sanitizedQuery.export &&
 		res.locals['cache'] !== false &&
 		exceedsMaxSize === false &&
-		req.originalUrl?.startsWith('/auth')
+		!req.originalUrl?.startsWith('/auth')
 	) {
 		const key = getCacheKey(req);
 


### PR DESCRIPTION
## Change description

Bypass cache only when url starts with `/auth`

## Type of change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

With the current settings, only the request starting with `/auth` are cached.
We want the reversed.

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
- 
### Code review

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [X] reviewers assigned 
- [X] Pull request linked to task tracker where applicable

