### PR TITLE
restrain access token to /assets

### DIFF
--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -95,7 +95,7 @@ export const ACCESS_COOKIE_OPTIONS: CookieOptions = {
 	maxAge: getMilliseconds(env['ACCESS_TOKEN_TTL']),
 	secure: env['ACCESS_TOKEN_COOKIE_SECURE'] ?? false,
 	sameSite: (env['ACCESS_TOKEN_COOKIE_SAME_SITE'] as 'lax' | 'strict' | 'none') || 'strict',
-	path: '/',
+	path: '/assets',
 };
 
 const {

--- a/api/src/middleware/extract-token.ts
+++ b/api/src/middleware/extract-token.ts
@@ -29,7 +29,7 @@ const extractToken: RequestHandler = (req, _res, next) => {
 	 * Check if there is an access token stored in the cookies
 	 */
 
-	if (req?.cookies?.[env['ACCESS_TOKEN_COOKIE_NAME'] as string]) {
+	if (req?.cookies?.[env['ACCESS_TOKEN_COOKIE_NAME'] as string] && req.path.startsWith('/assets/')) {
 		token = req.cookies[env['ACCESS_TOKEN_COOKIE_NAME'] as string];
 	}
 


### PR DESCRIPTION
## Change description

> Access Token was added to cookies here #60 and it was then made possible to make any request to the api without a bearer token. This makes it possible to make api requests with the access token in the cookies.
This PR fixes that behaviour by allowing to use the access token in the cookies only for the GET /assets route.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [X] Security fix

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [ ] Changes to network configurations have been reviewed
- [ ] Any newly exposed public endpoints or data have gone through security review

### Code review

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] reviewers assigned 
- [ ] Pull request linked to task tracker where applicable

